### PR TITLE
Configuration of multiple WiFi client networks

### DIFF
--- a/image/wpa_supplicant.conf.template
+++ b/image/wpa_supplicant.conf.template
@@ -26,8 +26,12 @@ network={
 {{if eq .WiFiMode 2}}
 # AP+Client config
 ap_scan=1
+
+{{range .WiFiClientNetworks}}
 network={
-	ssid="{{.WiFiClientSSID}}"
-	psk="{{.WiFiClientPassword}}"
+	ssid="{{.SSID}}"
+	psk="{{.Password}}"
 }
+{{end}}
+
 {{end}}

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1184,8 +1184,7 @@ type settings struct {
 	WiFiMode             int
 	WiFiDirectPin        string
 	WiFiIPAddress        string
-	WiFiClientSSID       string
-	WiFiClientPassword   string
+	WiFiClientNetworks   []wifiClientNetwork
 	WiFiInternetPassThroughEnabled bool
 
 	EstimateBearinglessDist bool
@@ -1288,6 +1287,7 @@ func defaultSettings() {
 	globalSettings.WiFiPassphrase = ""
 	globalSettings.WiFiSSID = "stratux"
 	globalSettings.WiFiSecurityEnabled = false
+	globalSettings.WiFiClientNetworks = make([]wifiClientNetwork, 0)
 
 	globalSettings.RadarLimits = 2000
 	globalSettings.RadarRange = 10

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -465,10 +465,13 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 						setWiFiMode(int(val.(float64)))
 					case "WiFiDirectPin":
 						setWifiDirectPin(val.(string))
-					case "WiFiClientSSID":
-						setWifiClientSSID(val.(string))
-					case "WiFiClientPassword":
-						setWifiClientPassword(val.(string))
+					case "WiFiClientNetworks":
+						var networks = make([]wifiClientNetwork, 0)
+						for _, rawNetwork := range val.([]interface{}) {
+							network := rawNetwork.(map[string]interface{})
+							networks = append(networks, wifiClientNetwork{network["SSID"].(string), network["Password"].(string)})
+						}
+						setWifiClientNetworks(networks)
 					case "WiFiInternetPassThroughEnabled":
 						setWifiInternetPassthroughEnabled(val.(bool))
 					case "EstimateBearinglessDist":

--- a/main/networksettings.go
+++ b/main/networksettings.go
@@ -37,9 +37,12 @@ type NetworkTemplateParams struct {
 	WiFiChannel      int
 	WiFiDirectPin    string
 	WiFiPassPhrase   string
-	WiFiClientSSID   string
-	WiFiClientPassword string
+	WiFiClientNetworks []wifiClientNetwork
 	WiFiInternetPassThroughEnabled bool
+}
+type wifiClientNetwork struct {
+	SSID     string
+	Password string
 }
 
 var hasChanged bool
@@ -98,17 +101,19 @@ func setWifiDirectPin(pin string) {
 	}
 }
 
-func setWifiClientSSID(ssid string) {
-	if globalSettings.WiFiClientSSID != ssid {
-		globalSettings.WiFiClientSSID = ssid
+func setWifiClientNetworks(networks []wifiClientNetwork) {
+	if len(globalSettings.WiFiClientNetworks) != len(networks) {
+		globalSettings.WiFiClientNetworks = networks
 		hasChanged = true
+		return
 	}
-}
 
-func setWifiClientPassword(password string) {
-	if globalSettings.WiFiClientPassword != password {
-		globalSettings.WiFiClientPassword = password
-		hasChanged = true
+	for i, net := range networks {
+		if globalSettings.WiFiClientNetworks[i].SSID != net.SSID || globalSettings.WiFiClientNetworks[i].Password != net.Password {
+			globalSettings.WiFiClientNetworks = networks
+			hasChanged = true
+			return
+		}
 	}
 }
 
@@ -156,8 +161,7 @@ func applyNetworkSettings(force bool, onlyWriteFiles bool) {
 	tplSettings.WiFiChannel = globalSettings.WiFiChannel
 	tplSettings.WiFiSSID = globalSettings.WiFiSSID
 	tplSettings.WiFiDirectPin = globalSettings.WiFiDirectPin
-	tplSettings.WiFiClientSSID = globalSettings.WiFiClientSSID
-	tplSettings.WiFiClientPassword = globalSettings.WiFiClientPassword
+	tplSettings.WiFiClientNetworks = globalSettings.WiFiClientNetworks
 	tplSettings.WiFiInternetPassThroughEnabled = globalSettings.WiFiInternetPassThroughEnabled
 	
 	if tplSettings.WiFiChannel == 0 {

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -72,8 +72,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.WiFiMode = settings.WiFiMode.toString();
 		$scope.WiFiDirectPin = settings.WiFiDirectPin;
 
-		$scope.WiFiClientSSID = settings.WiFiClientSSID;
-		$scope.WiFiClientPassword = settings.WiFiClientPassword;
+		$scope.WiFiClientNetworks = settings.WiFiClientNetworks;
 		$scope.WiFiInternetPassThroughEnabled = settings.WiFiInternetPassThroughEnabled;
 
         $scope.Channels = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
@@ -324,6 +323,22 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		});
     };
 
+    $scope.addWiFiClientNetwork = function () {
+        $scope.WiFiClientNetworks.push({
+            SSID: '',
+            Password: ''
+        });
+		$scope.$apply();
+    };
+
+    $scope.removeWiFiClientNetwork = function (Network) {
+        var idx = $scope.WiFiClientNetworks.indexOf(Network);
+        if (idx >= 0) {
+            $scope.WiFiClientNetworks.splice(idx, 1);
+        }
+		$scope.$apply();
+    };
+
     $scope.updateWiFi = function(action) {
         $scope.WiFiErrors = {
             'WiFiSSID': '',
@@ -358,8 +373,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 				"WiFiIPAddress" : $scope.WiFiIPAddress,
 				"WiFiMode" : parseInt($scope.WiFiMode),
 				"WiFiDirectPin": $scope.WiFiDirectPin,
-				"WiFiClientSSID": $scope.WiFiClientSSID,
-				"WiFiClientPassword": $scope.WiFiClientPassword,
+				"WiFiClientNetworks": $scope.WiFiClientNetworks,
 				"WiFiInternetPassThroughEnabled": $scope.WiFiInternetPassThroughEnabled
             };
 

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -261,18 +261,33 @@
                                 placeholder="192.168.10.1" />
                         </div>
                         <div class="form-group reset-flow" ng-show="WiFiMode=='2'">
-                            <label class="control-label col-xs-5">WiFi Client SSID</label>
-                            <input class="col-xs-7" type="text" ssid-input ng-model="WiFiClientSSID" />
-                        </div>
-                        <div class="form-group reset-flow" ng-show="WiFiMode=='2'">
-                            <label class="control-label col-xs-5">WiFi Client Passphrase</label>
-                            <input class="col-xs-7" type="text" wpa-input ng-model="WiFiClientPassword" />
-                        </div>
-                        <div class="form-group reset-flow" ng-show="WiFiMode=='2'">
                             <label class="control-label col-xs-5">Internet Passthrough</label>
                             <div class="col-xs-5">
                                 <ui-switch ng-model="WiFiInternetPassThroughEnabled" settings-change></ui-switch>
                             </div>
+                        </div>
+
+                        <div class="form-group reset-flow" ng-show="WiFiMode=='2'">
+                            <button class="btn btn-info btn-block" ng-click="addWiFiClientNetwork()">Add
+                                WiFi Client Network</button>
+                        </div>
+
+                        <hr>
+
+                        <div ng-show="WiFiMode=='2'" ng-repeat="Network in WiFiClientNetworks">
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">WiFi Client SSID</label>
+                                <input class="col-xs-7" type="text" ssid-input ng-model="Network.SSID" />
+                            </div>
+                            <div class="form-group reset-flow">
+                                <label class="control-label col-xs-5">WiFi Client Passphrase</label>
+                                <input class="col-xs-7" type="text" wpa-input ng-model="Network.Password" />
+                            </div>
+                            <div class="form-group reset-flow">
+                                <button class="btn btn-info btn-block" ng-click="removeWiFiClientNetwork(Network)">Remove
+                                    WiFi Client Network</button>
+                            </div>
+                            <hr>
                         </div>
 
                         <div class="form-group reset-flow">


### PR DESCRIPTION
This PR adds support to allow the configuration of multiple WiFi client networks.

I saw someone else who also wanted this feature in the discussions of 1.6r1-eu026 and decided to just give it a try.
In the settings UI you can now add any number of client networks when the mode is set to "AP+Client".

What do you think?

![Screenshot 2021-10-26 211002](https://user-images.githubusercontent.com/2939446/138946362-7d709542-0391-406b-820c-9d3f5c202ae0.png)
