### PR TITLE
Dpkg support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ ogn/esp32-ogn-tracker
 
 *.mp4
 
+*.deb
+
 *.img
 
 #*.zip

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 export STRATUX_HOME := /opt/stratux/
+export DEBPKG_BASE := /tmp/dpkg-stratux/stratux
+export DEBPKG_HOME := /tmp/dpkg-stratux/stratux/opt/stratux
+VERSIONSTR := $(shell ./image/getversion.sh)
+THISARCH = $(shell ./image/getarch.sh)
+
 ifeq "$(CIRCLECI)" "true"
 	BUILDINFO=
 	PLATFORMDEPENDENT=
 else
-	LFLAGS=-X main.stratuxVersion=`git describe --tags --abbrev=0` -X main.stratuxBuild=`git log -n 1 --pretty=%H`  
+	LFLAGS=-X main.stratuxVersion=$(VERSIONSTR) -X main.stratuxBuild=`git log -n 1 --pretty=%H`  
 	BUILDINFO=-ldflags "$(LFLAGS)"
 	BUILDINFO_STATIC=-ldflags "-extldflags -static $(LFLAGS)"
 	PLATFORMDEPENDENT=fancontrol
@@ -105,9 +110,66 @@ install: optinstall
 	chmod 644 /lib/systemd/system/stratux.service
 	ln -fs /lib/systemd/system/stratux.service /etc/systemd/system/multi-user.target.wants/stratux.service
 
+#
+# Debian package related targets below
+#
 
+.PHONY: prep_dpkg
+prep_dpkg:
+	rm -rf $(DEBPKG_BASE)
+	mkdir -p $(DEBPKG_BASE)
+	mkdir $(DEBPKG_BASE)/DEBIAN
+
+.PHONY: wwwdpkg
+wwwdpkg: STRATUX_HOME=$(DEBPKG_HOME)
+wwwdpkg:
+	make -C web
+
+.PHONY: optinstall_dpkg
+
+optinstall_dpkg:  STRATUX_HOME=$(DEBPKG_HOME)
+optinstall_dpkg: optinstall
+
+dpkg: prep_dpkg wwwdpkg ogn/ddb.json optinstall_dpkg
+	# Copy the control script to DEBIAN directory
+	cp -f image/control.dpkg $(DEBPKG_BASE)/DEBIAN/control
+	# Copy the preinstall script to DEBIAN directory
+	cp -f image/preinst.dpkg $(DEBPKG_BASE)/DEBIAN/preinst
+	# Copy the preinstall script to DEBIAN directory
+	cp -f image/postinst.dpkg $(DEBPKG_BASE)/DEBIAN/postinst
+	# Create the directories inside of the dpkg environment
+	mkdir -p $(DEBPKG_BASE)/etc/udev/rules.d/
+	mkdir -p $(DEBPKG_BASE)/lib/systemd/system/
+	# Copy the udev rules to the dpkg environment
+	cp -f image/10-stratux.rules $(DEBPKG_BASE)/etc/udev/rules.d/10-stratux.rules
+	cp -f image/99-uavionix.rules $(DEBPKG_BASE)/etc/udev/rules.d/99-uavionix.rules
+	# Copy the systemd scripts to the dpkg environment
+	cp __lib__systemd__system__stratux.service $(DEBPKG_BASE)/lib/systemd/system/stratux.service
+	chmod 644 $(DEBPKG_BASE)/lib/systemd/system/stratux.service
+	#ln -s $(DEBPKG_BASE)/lib/systemd/system/stratux.service $(DEBPKG_BASE)/etc/systemd/system/multi-user.target.wants/stratux.service	
+	# Set up the versioning inside of the dpkg system. This puts the version number inside of the config file
+	sed -i 's/VERSION/$(VERSIONSTR)/g' $(DEBPKG_BASE)/DEBIAN/control
+	# set up the arch inside of the dpkg System. We have to use a script because x86_64 is arm64, aarch64 is arm64, etc.
+	sed -i 's/ARCH/$(THISARCH)/g' $(DEBPKG_BASE)/DEBIAN/control
+    # Set permissions of the scripts for dpkg
+	chmod 755 $(DEBPKG_BASE)/DEBIAN/control
+	chmod 755 $(DEBPKG_BASE)/DEBIAN/preinst
+	chmod 755 $(DEBPKG_BASE)/DEBIAN/postinst	
+	# Create the default US settings for the config default
+	echo '{"UAT_Enabled": true,"OGN_Enabled": false,"DeveloperMode": false}' > $(DEBPKG_HOME)/cfg/stratux.conf.default
+	# Create the debian package for US
+	dpkg-deb -b $(DEBPKG_BASE)
+	# Rename the file and move it to the base directory. Include the arch in the name
+	mv -f $(DEBPKG_BASE)/../stratux.deb ./stratux-$(VERSIONSTR)-$(THISARCH)-US.deb
+	#Ceate the default EU settings for the config default
+	echo '{"OGN_Enabled": true, "DeveloperMode": true}' > $(DEBPKG_HOME)/cfg/stratux.conf.default
+	# Create the debian package for EU
+	dpkg-deb -b $(DEBPKG_BASE)
+	# Rename the file and move it to the base directory. Include the arch in the name
+	mv -f $(DEBPKG_BASE)/../stratux.deb ./stratux-$(VERSIONSTR)-$(THISARCH)-EU.deb
+	
 clean:
-	rm -f gen_gdl90 libdump978.so fancontrol ahrs_approx
+	rm -f gen_gdl90 libdump978.so fancontrol ahrs_approx *.deb
 	cd dump1090 && make clean
 	cd dump978 && make clean
 	cd rtl-ais && make clean

--- a/image/control.dpkg
+++ b/image/control.dpkg
@@ -1,0 +1,8 @@
+Package: stratux
+Version: VERSION
+Section: utils
+Priority: optional
+Architecture: ARCH
+Maintainer: Admin admin@stratux.me
+Vcs-Git: git@github.com:stratux/stratux.git
+Description: A low cost ADS-B receivers for pilots.

--- a/image/getarch.sh
+++ b/image/getarch.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+ARCH=$(uname -m)
+if [ "$ARCH" == "x86_64" ]; then
+	ARCH="amd64"
+fi
+if [ "$ARCH" == "aarch64" ]; then
+	ARCH="arm64"
+fi
+echo $ARCH

--- a/image/getversion.sh
+++ b/image/getversion.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+VER=$(git describe --tags --abbrev=0)
+if [ "${VER:0:1}" == "v" ]; then
+	VER=${VER:1}
+fi
+echo $VER

--- a/image/postinst.dpkg
+++ b/image/postinst.dpkg
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo "Post install script for stratux is running.."
+systemctl daemon-reload
+systemctl enable stratux
+systemctl restart udev
+systemctl start stratux
+if [ -f "/opt/stratux/bin/fancontrol" ]; then
+	/opt/stratux/bin/fancontrol start
+fi

--- a/image/preinst.dpkg
+++ b/image/preinst.dpkg
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Running pre-installation script and stopping the stratux service"
+if [ -f "/opt/stratux/bin/fancontrol" ]; then
+	/opt/stratux/bin/fancontrol stop
+fi
+# Example: Stop the stratux service before installing a new version
+systemctl stop stratux 2>/dev/null || true


### PR DESCRIPTION
Adds the creation of both US and EU Debian packages for distribution. I changed the handling of the two configs to have `/opt/stratux/cfg/stratux.conf.defaut` that reads in the defaults for each region. This file differs between each different `.deb` package. If `stratux.conf` is not yet in `/boot/firmware`, it will copy that default on top of the config file and will be read in and overwritten by the system. 

Some work may remain but this is a start.