### PR TITLE
docker-compose.yaml - Set 'platform: linux/arm64/v8' as the target is…

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@
 services:
   cli:
     image: stratux_debian
+    platform: linux/arm64/v8
     environment:
       GOCACHE: "/tmp/go-cache"
       GOMODCACHE: "/tmp/go/pkg/mod"


### PR DESCRIPTION
… a raspberry pi running a 64bit operating system.

Fixes issue where container building on an x86-64 machine was resulting in a debian:bookworm x86-64 image running and generating x86-64 debian packages which makes no sense.