### PR TITLE
Update settings to have the SSID be Stratux instead of stratux

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1367,7 +1367,7 @@ func defaultSettings() {
 	globalSettings.WiFiChannel = 1
 	globalSettings.WiFiIPAddress = "192.168.10.1"
 	globalSettings.WiFiPassphrase = ""
-	globalSettings.WiFiSSID = "stratux"
+	globalSettings.WiFiSSID = "Stratux"
 	globalSettings.WiFiSecurityEnabled = false
 	globalSettings.WiFiClientNetworks = make([]wifiClientNetwork, 0)
 

--- a/main/networksettings.go
+++ b/main/networksettings.go
@@ -182,7 +182,7 @@ func applyNetworkSettings(force bool, onlyWriteFiles bool) {
 	}
 	
 	if tplSettings.WiFiSSID == "" {
-		tplSettings.WiFiSSID = "stratux"
+		tplSettings.WiFiSSID = "Stratux"
 	}
 
 	f := func() {


### PR DESCRIPTION
@Helno had specified in a previous merge that the SSID would be set to `Stratux`. Applying the same rule, I changed the defaults to reflect this setting.