### PR TITLE
Fix ARCH detection for OGN.. ARCH uses arm64 instead of aarch64, and …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ ifeq ($(debug),true)
 	BUILDINFO := -gcflags '-N -l' $(BUILDINFO)
 endif
 
-ifeq ($(ARCH),aarch64)
+ifeq ($(ARCH),arm64)
 	OGN_RX_BINARY=ogn/ogn-rx-eu_aarch64
-else ifeq ($(ARCH),x86_64)
+else ifeq ($(ARCH),amd64)
 	OGN_RX_BINARY=ogn/ogn-rx-eu_x86
 else
 	OGN_RX_BINARY=ogn/ogn-rx-eu_arm


### PR DESCRIPTION
…amd64 instead of x86_64 inside of the makefile