### PR TITLE
Added libjpeg62-turbo because OGN binary depends on it

### DIFF
--- a/image_build/stage2/10-stratux/02-run.sh
+++ b/image_build/stage2/10-stratux/02-run.sh
@@ -10,6 +10,7 @@ DEB_FILENAME_TMP=${ROOTFS_DIR}/tmp/${DEB_NAME}
 on_chroot << EOF
     # needed for OGN for some reason
     apt install --yes libjpeg62-turbo
+    # needed for dump1090
     apt install -y libncurses6 
     dpkg -i /tmp/${DEB_NAME}
 EOF

--- a/image_build/stage2/10-stratux/02-run.sh
+++ b/image_build/stage2/10-stratux/02-run.sh
@@ -8,7 +8,9 @@ DEB_FILENAME_TMP=${ROOTFS_DIR}/tmp/${DEB_NAME}
 # copy dpkg into /tmp directory so its available in the chroot
 (cp ../../stratux/${DEB_NAME} ${DEB_FILENAME_TMP})
 on_chroot << EOF
-    apt install -y libncurses6
+    # needed for OGN for some reason
+    apt install --yes libjpeg62-turbo
+    apt install -y libncurses6 
     dpkg -i /tmp/${DEB_NAME}
 EOF
 


### PR DESCRIPTION
`ogn-rx-eu` depends on `libjpeg62` apparently. Weird.