### PR TITLE
Fixes #398: Update wpa_supplicant.conf.template for open client networks

### DIFF
--- a/debian/wpa_supplicant.conf.template
+++ b/debian/wpa_supplicant.conf.template
@@ -33,12 +33,8 @@ ap_scan=1
 
 {{range .WiFiClientNetworks}}
 network={
-	ssid="{{.SSID}}"
-	{{if .Password}}
-    psk="{{.Password}}"
-    {{else}}
-    key_mgmt=NONE
-    {{end}}
+ssid="{{.SSID}}"
+{{if .Password}}psk="{{.Password}}"{{else}}key_mgmt=NONE{{end}}
 }
 {{end}}
 

--- a/debian/wpa_supplicant.conf.template
+++ b/debian/wpa_supplicant.conf.template
@@ -34,7 +34,11 @@ ap_scan=1
 {{range .WiFiClientNetworks}}
 network={
 	ssid="{{.SSID}}"
-	psk="{{.Password}}"
+	{{if .Password}}
+    psk="{{.Password}}"
+    {{else}}
+    key_mgmt=NONE
+    {{end}}
 }
 {{end}}
 


### PR DESCRIPTION
Fixes #398:  wpa_supplicant requires key_mgmt=NONE for open networks, not an empty psk.

