### PR TITLE
Add GPSLatitude and GPSLongitude to sensors_*.csv log

### DIFF
--- a/main/sensors.go
+++ b/main/sensors.go
@@ -427,6 +427,8 @@ func updateExtraLogging() {
 	logMap["GPSTrueCourse"] = mySituation.GPSTrueCourse
 	logMap["GPSVerticalAccuracy"] = mySituation.GPSVerticalAccuracy
 	logMap["GPSHorizontalAccuracy"] = mySituation.GPSHorizontalAccuracy
+	logMap["GPSLatitude"] = mySituation.GPSLatitude
+	logMap["GPSLongitude"] = mySituation.GPSLongitude
 	logMap["GPSAltitudeMSL"] = mySituation.GPSAltitudeMSL
 	logMap["GPSFixQuality"] = float64(mySituation.GPSFixQuality)
 	logMap["BaroPressureAltitude"] = float64(mySituation.BaroPressureAltitude)


### PR DESCRIPTION
Fixes #393.

Adds `GPSLatitude` and `GPSLongitude` to `updateExtraLogging()` in `main/sensors.go`, so they appear in `sensors_*.csv` alongside the existing `GPSAltitudeMSL` and accuracy fields.

This allows flight logs to be imported into analysis sites like [flysto.net](https://flysto.net/) without needing a separate GPS data source.

**Change:** Two lines added to `updateExtraLogging()`:
```go
logMap["GPSLatitude"]  = mySituation.GPSLatitude
logMap["GPSLongitude"] = mySituation.GPSLongitude
```

**Code generated by:** AI assistant based on the suggestion in #393. Human review recommended before merge.