### PR TITLE
Fix .deb update path in stratux-pre-start.sh

### DIFF
--- a/debian/stratux-pre-start.sh
+++ b/debian/stratux-pre-start.sh
@@ -57,7 +57,7 @@ fi
 # package based update in download location
 if [ -e ${TEMP_PACKAGE_LOCATION} ]; then
 	wLog "Found Update Package in $TEMP_PACKAGE_LOCATION$PACKAGE_MASK"
-	TEMP_PACKAGE_FILE=`ls -1t ${TEMP_PACAGE_LOCATION} | head -1`
+	TEMP_PACKAGE_FILE=`ls -1t ${TEMP_PACKAGE_LOCATION} | head -1`
 	wLog "Moving Update Package $TEMP_PACKAGE_FILE"
 	cp -r ${TEMP_PACKAGE_FILE} /root/
 	wLog "Changing permissions to chmod a+x $PACKAGE_UPDATE_LOCATION"
@@ -72,7 +72,7 @@ if [ -e ${PACKAGE_UPDATE_LOCATION} ]; then
 	if [ -n ${UPDATE_PACKAGE_FILE} ] ; then
 		# Install the new packagepackage, remove it, then reboot.
 		wLog "Installing update package ${UPDATE_PACKAGE_FILE}..."
-		bash dpkg -i ${UPDATE_PACKAGE_FILE}
+		dpkg -i ${UPDATE_PACKAGE_FILE}
 		wLog "Removing Update Package"
 		rm -f ${UPDATE_PACKAGE_FILE}
 		wLog "Finished... Rebooting... Bye"


### PR DESCRIPTION
Fixes two bugs that prevented `.deb` files dropped in `/boot/firmware/StratuxUpdates/` from being applied on boot.

**Bug 1 — typo in variable name (line 60):**
```bash
# Before (broken — TEMP_PACAGE_LOCATION is undefined, ls gets empty string)
TEMP_PACKAGE_FILE=`ls -1t ${TEMP_PACAGE_LOCATION} | head -1`

# After
TEMP_PACKAGE_FILE=`ls -1t ${TEMP_PACKAGE_LOCATION} | head -1`
```

**Bug 2 — spurious `bash` before `dpkg` (line 72):**
```bash
# Before (bash tries to execute 'dpkg' as a script argument, fails)
bash dpkg -i ${UPDATE_PACKAGE_FILE}

# After
dpkg -i ${UPDATE_PACKAGE_FILE}
```

With these fixed, the `.deb` update path works identically to the `.sh` path: drop a `stratux*.deb` into the FAT32 boot partition's `StratuxUpdates/` folder, reboot, done.

Initiated by @Helno. Found via code review by multivac-ops AI assistant.