### PR TITLE
Add stable GPS fields to extra log

### DIFF
--- a/main/sensors.go
+++ b/main/sensors.go
@@ -427,16 +427,8 @@ func updateExtraLogging() {
 	logMap["GPSTrueCourse"] = mySituation.GPSTrueCourse
 	logMap["GPSVerticalAccuracy"] = mySituation.GPSVerticalAccuracy
 	logMap["GPSHorizontalAccuracy"] = mySituation.GPSHorizontalAccuracy
-	if mySituation.GPSLatitude != 0 {
-		logMap["GPSLatitude"] = mySituation.GPSLatitude
-	} else {
-		logMap["GPSLatitude"] = 0.0
-	}
-	if mySituation.GPSLongitude != 0 {
-		logMap["GPSLongitude"] = mySituation.GPSLongitude
-	} else {
-		logMap["GPSLongitude"] = 0.0
-	}
+	logMap["GPSLatitude"] = mySituation.GPSLatitude
+	logMap["GPSLongitude"] = mySituation.GPSLongitude
 	if !mySituation.GPSTime.IsZero() {
 		logMap["GPSTime"] = float64(mySituation.GPSTime.UTC().Unix())
 	} else {

--- a/main/sensors.go
+++ b/main/sensors.go
@@ -427,8 +427,22 @@ func updateExtraLogging() {
 	logMap["GPSTrueCourse"] = mySituation.GPSTrueCourse
 	logMap["GPSVerticalAccuracy"] = mySituation.GPSVerticalAccuracy
 	logMap["GPSHorizontalAccuracy"] = mySituation.GPSHorizontalAccuracy
-	logMap["GPSLatitude"] = mySituation.GPSLatitude
-	logMap["GPSLongitude"] = mySituation.GPSLongitude
+	if mySituation.GPSLatitude != 0 {
+		logMap["GPSLatitude"] = mySituation.GPSLatitude
+	} else {
+		logMap["GPSLatitude"] = 0.0
+	}
+	if mySituation.GPSLongitude != 0 {
+		logMap["GPSLongitude"] = mySituation.GPSLongitude
+	} else {
+		logMap["GPSLongitude"] = 0.0
+	}
+	if !mySituation.GPSTime.IsZero() {
+		logMap["GPSTime"] = float64(mySituation.GPSTime.UTC().Unix())
+	} else {
+		logMap["GPSTime"] = 0.0
+	}
+	logMap["GPSLastFixTimeSinceMidnight"] = float64(mySituation.GPSLastFixSinceMidnightUTC)
 	logMap["GPSAltitudeMSL"] = mySituation.GPSAltitudeMSL
 	logMap["GPSFixQuality"] = float64(mySituation.GPSFixQuality)
 	logMap["BaroPressureAltitude"] = float64(mySituation.BaroPressureAltitude)


### PR DESCRIPTION
## Summary

Improve the extra log output so GPS fields are emitted in a stable, parseable shape for downstream tooling.

## Changes

- always emit `GPSLatitude` and `GPSLongitude`, using `0.0` when no value is available
- add `GPSTime` as a UTC Unix timestamp, using `0.0` when no GPS time is available
- add `GPSLastFixTimeSinceMidnight`

This addresses the follow-up requested in #425 and improves compatibility with log converters such as Flysto's simulated ForeFlight import flow.

## Attribution

These code changes were implemented by GitHub Copilot CLI for @Helno.
