### PR TITLE
Fix .deb SD card update mechanism for overlay filesystem

### DIFF
--- a/debian/stratux-pre-start.sh
+++ b/debian/stratux-pre-start.sh
@@ -26,56 +26,100 @@ TEMP_PACKAGE_LOCATION="$TEMP_DIRECTORY/$PACKAGE_MASK"
 # packages are placed here for update
 PACKAGE_UPDATE_LOCATION="/root/$PACKAGE_MASK"
 
+# Detect whether the overlay filesystem is currently active.
+# /overlay/robase is always present (used by overlayctl for management), so we
+# check the root mount type instead of directory existence.
+overlay_is_active() {
+	[ "$(findmnt -n -o FSTYPE /)" = "overlay" ]
+}
+
 ###############
-# script based update in download location
+# Stage 1 (overlay active): script in SD card download location.
+# Copy it directly to the lower ext4 layer so it survives the reboot.
 if [ -e ${TEMP_SCRIPT_LOCATION} ]; then
-	wLog "Found Update Script in $TEMP_SCRIPT_LOCATION$SCRIPT_MASK"
 	TEMP_SCRIPT_FILE=`ls -1t ${TEMP_SCRIPT_LOCATION} | head -1`
-	wLog "Moving Update Script $TEMP_SCRIPT_FILE"
-	cp -r ${TEMP_SCRIPT_FILE} /root/
-	wLog "Changing permissions to chmod a+x $UPDATE_LOCATION"
-	chmod a+x ${SCRIPT_UPDATE_LOCATION}
-	wLog "Removing Script file from $TEMP_SCRIPT_LOCATION"
-	rm -rf ${TEMP_SCRIPT_FILE}
+	wLog "Found update script $TEMP_SCRIPT_FILE"
+	if overlay_is_active; then
+		wLog "Overlay active — staging script to ext4 lower layer and disabling overlay..."
+		/sbin/overlayctl unlock
+		cp "${TEMP_SCRIPT_FILE}" /overlay/robase/root/
+		chmod a+x /overlay/robase/root/$(basename "${TEMP_SCRIPT_FILE}")
+		rm -f "${TEMP_SCRIPT_FILE}"
+		/sbin/overlayctl disable
+		/sbin/overlayctl lock
+		wLog "Script staged. Rebooting to apply on bare ext4..."
+		reboot
+	else
+		# Overlay already inactive — copy to /root/ for next section to pick up
+		cp "${TEMP_SCRIPT_FILE}" /root/
+		chmod a+x /root/$(basename "${TEMP_SCRIPT_FILE}")
+		rm -f "${TEMP_SCRIPT_FILE}"
+	fi
 fi
 
-# script based update to apply
+# Stage 2 (overlay inactive): execute the update script from /root/
 if [ -e ${SCRIPT_UPDATE_LOCATION} ]; then
 	UPDATE_SCRIPT_FILE=`ls -1t ${SCRIPT_UPDATE_LOCATION} | head -1`
-	if [ -n ${UPDATE_SCRIPT_FILE} ] ; then
-		# Execute the script, remove it, then reboot.
-		wLog "Installing update script ${UPDATE_SCRIPT_FILE}..."
-		bash ${UPDATE_SCRIPT_FILE}
-		wLog "Removing Update Script"
-		rm -f ${UPDATE_SCRIPT_FILE}
-		wLog "Finished... Rebooting... Bye"
+	if [ -n "${UPDATE_SCRIPT_FILE}" ]; then
+		wLog "Executing update script ${UPDATE_SCRIPT_FILE}..."
+		# Move to /tmp and re-enable overlay before running, in case the script
+		# triggers a service restart that kills this ExecStartPre process.
+		UPDATE_TEMP_SCRIPT="/tmp/$(basename "${UPDATE_SCRIPT_FILE}")"
+		mv "${UPDATE_SCRIPT_FILE}" "${UPDATE_TEMP_SCRIPT}"
+		rm -f /overlay/disable
+		if bash "${UPDATE_TEMP_SCRIPT}"; then
+			wLog "Update script completed successfully."
+		else
+			wLog "ERROR: Update script ${UPDATE_SCRIPT_FILE} failed."
+		fi
+		rm -f "${UPDATE_TEMP_SCRIPT}"
+		wLog "Finished. Rebooting..."
 		reboot
 	fi
 fi
 
 ##############
-# package based update in download location
+# Stage 1 (overlay active): deb in SD card download location.
+# Copy it directly to the lower ext4 layer so it survives the reboot,
+# then disable overlay so the next boot runs dpkg on bare ext4.
 if [ -e ${TEMP_PACKAGE_LOCATION} ]; then
-	wLog "Found Update Package in $TEMP_PACKAGE_LOCATION$PACKAGE_MASK"
 	TEMP_PACKAGE_FILE=`ls -1t ${TEMP_PACKAGE_LOCATION} | head -1`
-	wLog "Moving Update Package $TEMP_PACKAGE_FILE"
-	cp -r ${TEMP_PACKAGE_FILE} /root/
-	wLog "Changing permissions to chmod a+x $PACKAGE_UPDATE_LOCATION"
-	chmod a+x ${PACKAGE_UPDATE_LOCATION}
-	wLog "Removing Update file from $TEMP_PACKAGE_LOCATION"
-	rm -rf ${TEMP_PACKAGE_FILE}
+	wLog "Found update package $TEMP_PACKAGE_FILE"
+	if overlay_is_active; then
+		wLog "Overlay active — staging package to ext4 lower layer and disabling overlay..."
+		/sbin/overlayctl unlock
+		cp "${TEMP_PACKAGE_FILE}" /overlay/robase/root/
+		rm -f "${TEMP_PACKAGE_FILE}"
+		/sbin/overlayctl disable
+		/sbin/overlayctl lock
+		wLog "Package staged. Rebooting to install on bare ext4..."
+		reboot
+	else
+		# Overlay already inactive — copy to /root/ for next section to pick up
+		cp "${TEMP_PACKAGE_FILE}" /root/
+		rm -f "${TEMP_PACKAGE_FILE}"
+	fi
 fi
 
-# package based update to apply
+# Stage 2 (overlay inactive): install the deb from /root/ and re-enable overlay
 if [ -e ${PACKAGE_UPDATE_LOCATION} ]; then
 	UPDATE_PACKAGE_FILE=`ls -1t ${PACKAGE_UPDATE_LOCATION} | head -1`
-	if [ -n ${UPDATE_PACKAGE_FILE} ] ; then
-		# Install the new packagepackage, remove it, then reboot.
+	if [ -n "${UPDATE_PACKAGE_FILE}" ]; then
 		wLog "Installing update package ${UPDATE_PACKAGE_FILE}..."
-		dpkg -i ${UPDATE_PACKAGE_FILE}
-		wLog "Removing Update Package"
-		rm -f ${UPDATE_PACKAGE_FILE}
-		wLog "Finished... Rebooting... Bye"
+		# Move the deb to /tmp and re-enable overlay BEFORE calling dpkg.
+		# The dpkg postinst runs 'systemctl daemon-reload && systemctl start stratux'
+		# which will kill this ExecStartPre process via daemon-reload. By cleaning up
+		# first the system is in a consistent state even if dpkg kills this script.
+		UPDATE_TEMP_FILE="/tmp/$(basename "${UPDATE_PACKAGE_FILE}")"
+		mv "${UPDATE_PACKAGE_FILE}" "${UPDATE_TEMP_FILE}"
+		rm -f /overlay/disable
+		if dpkg -i --force-depends "${UPDATE_TEMP_FILE}"; then
+			wLog "Package installed successfully."
+		else
+			wLog "ERROR: dpkg failed to install ${UPDATE_TEMP_FILE}."
+		fi
+		rm -f "${UPDATE_TEMP_FILE}"
+		wLog "Finished. Rebooting..."
 		reboot
 	fi
 fi

--- a/debian/stratux-pre-start.sh
+++ b/debian/stratux-pre-start.sh
@@ -41,14 +41,16 @@ if [ -e ${TEMP_SCRIPT_LOCATION} ]; then
 	wLog "Found update script $TEMP_SCRIPT_FILE"
 	if overlay_is_active; then
 		wLog "Overlay active — staging script to ext4 lower layer and disabling overlay..."
-		/sbin/overlayctl unlock
-		cp "${TEMP_SCRIPT_FILE}" /overlay/robase/root/
-		chmod a+x /overlay/robase/root/$(basename "${TEMP_SCRIPT_FILE}")
-		rm -f "${TEMP_SCRIPT_FILE}"
-		/sbin/overlayctl disable
-		/sbin/overlayctl lock
-		wLog "Script staged. Rebooting to apply on bare ext4..."
-		reboot
+		if /sbin/overlayctl unlock && cp "${TEMP_SCRIPT_FILE}" /overlay/robase/root/; then
+			chmod a+x /overlay/robase/root/$(basename "${TEMP_SCRIPT_FILE}")
+			rm -f "${TEMP_SCRIPT_FILE}"
+			/sbin/overlayctl disable
+			wLog "Script staged. Rebooting to apply on bare ext4..."
+			reboot
+		else
+			wLog "ERROR: Failed to stage script to ext4 lower layer. Update aborted."
+			/sbin/overlayctl lock
+		fi
 	else
 		# Overlay already inactive — copy to /root/ for next section to pick up
 		cp "${TEMP_SCRIPT_FILE}" /root/
@@ -66,7 +68,7 @@ if [ -e ${SCRIPT_UPDATE_LOCATION} ]; then
 		# triggers a service restart that kills this ExecStartPre process.
 		UPDATE_TEMP_SCRIPT="/tmp/$(basename "${UPDATE_SCRIPT_FILE}")"
 		mv "${UPDATE_SCRIPT_FILE}" "${UPDATE_TEMP_SCRIPT}"
-		rm -f /overlay/disable
+		/sbin/overlayctl enable
 		if bash "${UPDATE_TEMP_SCRIPT}"; then
 			wLog "Update script completed successfully."
 		else
@@ -87,13 +89,15 @@ if [ -e ${TEMP_PACKAGE_LOCATION} ]; then
 	wLog "Found update package $TEMP_PACKAGE_FILE"
 	if overlay_is_active; then
 		wLog "Overlay active — staging package to ext4 lower layer and disabling overlay..."
-		/sbin/overlayctl unlock
-		cp "${TEMP_PACKAGE_FILE}" /overlay/robase/root/
-		rm -f "${TEMP_PACKAGE_FILE}"
-		/sbin/overlayctl disable
-		/sbin/overlayctl lock
-		wLog "Package staged. Rebooting to install on bare ext4..."
-		reboot
+		if /sbin/overlayctl unlock && cp "${TEMP_PACKAGE_FILE}" /overlay/robase/root/; then
+			rm -f "${TEMP_PACKAGE_FILE}"
+			/sbin/overlayctl disable
+			wLog "Package staged. Rebooting to install on bare ext4..."
+			reboot
+		else
+			wLog "ERROR: Failed to stage package to ext4 lower layer. Update aborted."
+			/sbin/overlayctl lock
+		fi
 	else
 		# Overlay already inactive — copy to /root/ for next section to pick up
 		cp "${TEMP_PACKAGE_FILE}" /root/
@@ -112,7 +116,7 @@ if [ -e ${PACKAGE_UPDATE_LOCATION} ]; then
 		# first the system is in a consistent state even if dpkg kills this script.
 		UPDATE_TEMP_FILE="/tmp/$(basename "${UPDATE_PACKAGE_FILE}")"
 		mv "${UPDATE_PACKAGE_FILE}" "${UPDATE_TEMP_FILE}"
-		rm -f /overlay/disable
+		/sbin/overlayctl enable
 		if dpkg -i --force-depends "${UPDATE_TEMP_FILE}"; then
 			wLog "Package installed successfully."
 		else

--- a/debian/stratux.service
+++ b/debian/stratux.service
@@ -3,7 +3,7 @@ Description=Stratux
 After=network.target bluetooth.target
 
 [Service]
-ExecStartPre=/opt/stratux/bin/stratux-pre-start.sh
+ExecStartPre=-/opt/stratux/bin/stratux-pre-start.sh
 ExecStart=/opt/stratux/bin/stratuxrun
 ExecStopPost=/usr/bin/killall dump1090 ogn-rx-eu rtl_ais stratuxrun 
 KillMode=process

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -846,7 +846,6 @@ func handleDownloadDBRequest(w http.ResponseWriter, r *http.Request) {
 func handleUpdatePostRequest(w http.ResponseWriter, r *http.Request) {
 	setNoCache(w)
 	setJSONHeaders(w)
-	overlayctl("unlock")
 	reader, err := r.MultipartReader()
 	if err != nil {
 		log.Printf("Update failed from %s (%s).\n", r.RemoteAddr, err.Error())
@@ -859,15 +858,14 @@ func handleUpdatePostRequest(w http.ResponseWriter, r *http.Request) {
 	var base_dir string
 
 	if common.IsRunningAsRoot() {
-		base_dir = "/overlay/robase/root"
-	} else
-	{
+		base_dir = "/boot/firmware/StratuxUpdates"
+	} else {
 		base_dir = "."
 		log.Printf("not running as root, using base_dir of %s", base_dir)
 	}
 
 	for {
-		part, err := reader.NextPart();
+		part, err := reader.NextPart()
 		if err != nil {
 			log.Printf("Update failed from %s (%s).\n", r.RemoteAddr, err.Error())
 			return
@@ -883,7 +881,7 @@ func handleUpdatePostRequest(w http.ResponseWriter, r *http.Request) {
 		temp_filename = fmt.Sprintf("%s/TMP_%s", base_dir, part.FileName())
 		upload_filename = fmt.Sprintf("%s/%s", base_dir, part.FileName())
 
-		fi, err := os.OpenFile(temp_filename, os.O_WRONLY | os.O_CREATE | os.O_TRUNC, 0666)
+		fi, err := os.OpenFile(temp_filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 		if err != nil {
 			log.Printf("Update failed from %s (%s).\n", r.RemoteAddr, err.Error())
 			return
@@ -900,8 +898,7 @@ func handleUpdatePostRequest(w http.ResponseWriter, r *http.Request) {
 
 	os.Rename(temp_filename, upload_filename)
 	log.Printf("%s uploaded %s for update.\n", r.RemoteAddr, upload_filename)
-	overlayctl("disable")
-	// Successful update upload. Now reboot.
+	// Successful update upload. stratux-pre-start.sh handles the rest on next boot.
 	go delayReboot()
 }
 

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -864,6 +864,14 @@ func handleUpdatePostRequest(w http.ResponseWriter, r *http.Request) {
 		log.Printf("not running as root, using base_dir of %s", base_dir)
 	}
 
+	// Ensure the upload directory exists. The SD card flow relies on the user
+	// creating this path manually; the web flow has no such step, so create it
+	// here to avoid a silent failure when os.OpenFile cannot create the file.
+	if err := os.MkdirAll(base_dir, 0755); err != nil {
+		log.Printf("Update failed from %s (%s).\n", r.RemoteAddr, err.Error())
+		return
+	}
+
 	for {
 		part, err := reader.NextPart()
 		if err != nil {


### PR DESCRIPTION
## Problem

The `.deb` SD card update path in `stratux-pre-start.sh` ran `dpkg -i` while the overlay filesystem was still active. Since the overlay's upper layer is a tmpfs, all dpkg writes were wiped on reboot, making the update appear to succeed but leaving the system unchanged.

The web UI upload path (`managementinterface.go`) was working correctly — it wrote the `.deb` directly to the ext4 lower layer and called `overlayctl disable` before rebooting.

## Solution

**`stratux-pre-start.sh`**: Implement a two-stage overlay-aware update flow for the SD card path:

**Stage 1** (overlay active, detected via `findmnt -n -o FSTYPE /`):
- Unlock the ext4 lower layer (`overlayctl unlock`)
- Copy the `.deb` directly to `/overlay/robase/root/` — bypasses tmpfs, writes persistently to ext4
- Call `overlayctl disable` so the next boot runs on bare ext4
- Reboot

**Stage 2** (no overlay, bare ext4):
- Move `.deb` from `/root/` to `/tmp/` and remove `/overlay/disable` **before** calling dpkg — observed in testing that `dpkg postinst` runs `systemctl daemon-reload && systemctl start stratux`, which can terminate the running ExecStartPre process before cleanup completes; doing cleanup first makes this safe
- Run `dpkg -i --force-depends`
- Reboot

**`managementinterface.go`**: Refactored web UI upload handler to write to `/boot/firmware/StratuxUpdates/` instead of directly to `/overlay/robase/root/`, routing both the SD card and web UI paths through the same two-stage pre-start.sh flow. The `/boot/firmware` FAT partition is a separate mount (not overlaid), so no `overlayctl` calls are needed in the handler.

**`stratux.service`**: Changed `ExecStartPre=` to `ExecStartPre=-` so a pre-start failure does not prevent Stratux from starting.

## Testing

Tested end-to-end on a live Stratux device:
- Placed `.deb` in `/boot/firmware/StratuxUpdates/`, rebooted
- Stage 1 ran (overlay active): staged `.deb` to ext4, disabled overlay, rebooted
- Stage 2 ran (bare ext4): dpkg installed successfully, overlay re-enabled, rebooted
- Post-reboot: overlay active, Stratux running
