### PR TITLE
Updates documentation for dev setup

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -9,4 +9,4 @@ community_bridge: # Replace with a single Community Bridge project-name e.g., cl
 liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
-custom: ["https://paypal.me/stratuxeu"]
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -25,7 +25,11 @@ You will also have to enable developer mode and persistent logging on the web in
 - Restart again and verify that persistent logging is enabled before you continue.
 
 ### Set root password
-Then connect to it via Putty/SSH and set a root password (`sudo passwd`).
+Then connect to it via Putty/SSH and set a root password
+```bash
+sudo -s
+passwd
+```
 
 ### Set the correct date
 ```bash
@@ -37,12 +41,9 @@ If you run out of disk space, persistent logging is probably disabled
 
 ```bash
 apt update
-apt install build-essential git ncurses-dev
-```
-Notes:
-Some dpkg errors are normal.
-
-```bash
+apt-mark hold linux-image-rpi-*
+apt install -y build-essential git ncurses-dev libusb-1.0-0-dev
+apt-mark unhold linux-image-rpi-*
 cd /tmp
 wget https://github.com/stratux/rtlsdr/releases/download/v1.0/librtlsdr0_2.0.2-2_arm64.deb
 dpkg -i librtlsdr0_2.0.2-2_arm64.deb
@@ -51,7 +52,7 @@ dpkg -i librtlsdr-dev_2.0.2-2_arm64.deb
 ```
 
 ### Clone the repo
-Now clone the Stratux repository and install go:
+Now clone the Stratux repository with submodules and install go:
 
 ```bash
 cd /root

--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -1,6 +1,6 @@
 ## Choices...
 If you want to start working on the Stratux code base, here are a few hints for a developer-friendly setup.
-Note that this only works as-is for the Stratux EU Edition.
+Note that this only works as-is for the Stratux image.
 
 You basically have two choices.
 - Remotely working on a PI
@@ -25,7 +25,7 @@ You will also have to enable developer mode and persistent logging on the web in
 - Restart again and verify that persistent logging is enabled before you continue.
 
 ### Set root password
-Then connect to it via Putty/SSH and set a root password
+Then connect to it via Putty/SSH and set a root password:
 ```bash
 sudo -s
 passwd
@@ -37,18 +37,18 @@ timedatectl set-ntp on
 ```
 
 ### Install build dependencies
-If you run out of disk space, persistent logging is probably disabled
+If you run out of disk space, persistent logging is probably disabled.
 
 ```bash
 apt update
-apt-mark hold linux-image-rpi-*
 apt install -y build-essential git ncurses-dev libusb-1.0-0-dev
-apt-mark unhold linux-image-rpi-*
 cd /tmp
 wget https://github.com/stratux/rtlsdr/releases/download/v1.0/librtlsdr0_2.0.2-2_arm64.deb
 dpkg -i librtlsdr0_2.0.2-2_arm64.deb
+rm librtlsdr0_2.0.2-2_arm64.deb
 wget https://github.com/stratux/rtlsdr/releases/download/v1.0/librtlsdr-dev_2.0.2-2_arm64.deb
 dpkg -i librtlsdr-dev_2.0.2-2_arm64.deb
+rm librtlsdr-dev_2.0.2-2_arm64.deb
 ```
 
 ### Clone the repo
@@ -67,15 +67,15 @@ Afterwards, install Visual Studio Code on your PC, and additionally install and 
 When done, connect to the RPi as root via Visual Studio Code.
 Then click `File->Open Folder` and type in `/root/stratux`.
 You should now have the Stratux project loaded into VSCode.
-There are preconfigured build an debug tasks in the project which allow you to create a debuggable Stratux build and remote-debug it in VSCode.
+There are preconfigured build and debug tasks in the project which allow you to create a debuggable Stratux build and remote-debug it in VSCode.
 To get started, you need to install the "Go" extensions ("Install on Stratux" while connected via Remote-SSH).
 The extension will ask you to install several tools (including delve if you want to debug). Go ahead and do so.
 Before debugging, run `stxstop` to stop the already running stratux service.
 
 There is also a makefile in the repository, so `make && make install && stxrestart` would be a simple way to build, install and start.
 
-### Save your public key to the pi
-Run on your local machine (On windows use git bash).  Stops VSCode from continually prompting for passwords
+### Save your public key to the Pi
+Run this on your local machine (on Windows, use Git Bash). This stops VSCode from continually prompting for passwords:
 
 ```bash
 ssh-copy-id root@stratux

--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -12,31 +12,73 @@ Working locally on a Linux machine is a bit harder to set up and requires some c
 We recommend working remotely on the Pi, preferably a Pi4.
 
 ## Remote Setup
-To work remotely on the PI, first, **make sure your Stratux is connected to the internet**. You will also have to **Enable persistent logging on the web interface** to make sure that the file system of the PI is writable.
+To work remotely on the PI, first **make sure your Stratux is connected to the internet**. 
 
-Additionally, keep in mind that the PI's CPU is clocked down by default in the Stratux image to save some power. This makes compiling stuff extremely slow. Therefore it is recommended to remove/comment the *_freq lines in /boot/config.txt (or /boot/firmware/config.txt starting with bookworm) and restarting it.
+### Turn up CPU and restart
+Keep in mind that the PI's CPU is clocked down by default in the Stratux image to save some power. This makes compiling stuff extremely slow. Therefore it is recommended to remove/comment the *_freq lines in `/boot/config.txt` (or `/boot/firmware/config.txt` starting with bookworm) and restarting it.
 
+### Enable Developer mode
+You will also have to enable developer mode and persistent logging on the web interface to make sure that the file system of the PI is writable.
+
+- Enable Developer mode by visiting the status page and repeatedly clicking the version number at the top of the screen.
+- Navigate to **Settings > Diagnostics > Persistent logging** and enable it.
+- Restart again and verify that persistent logging is enabled before you continue.
+
+### Set root password
 Then connect to it via Putty/SSH and set a root password (`sudo passwd`).
-Now clone the Stratux repository and install some dependencies/go:
+
+### Set the correct date
 ```bash
-sudo -s
-apt install build-essential git
+timedatectl set-ntp on
+```
+
+### Install build dependencies
+If you run out of disk space, persistent logging is probably disabled
+
+```bash
+apt update
+apt install build-essential git ncurses-dev
+```
+Notes:
+Some dpkg errors are normal.
+
+```bash
+cd /tmp
+wget https://github.com/stratux/rtlsdr/releases/download/v1.0/librtlsdr0_2.0.2-2_arm64.deb
+dpkg -i librtlsdr0_2.0.2-2_arm64.deb
+wget https://github.com/stratux/rtlsdr/releases/download/v1.0/librtlsdr-dev_2.0.2-2_arm64.deb
+dpkg -i librtlsdr-dev_2.0.2-2_arm64.deb
+```
+
+### Clone the repo
+Now clone the Stratux repository and install go:
+
+```bash
 cd /root
 git clone --recursive https://github.com/stratux/stratux.git
 wget https://golang.org/dl/go1.20.1.linux-arm64.tar.gz
 tar xzf go1.20.1.linux-arm64.tar.gz
 rm go1.20.1.linux-arm64.tar.gz
 ```
+
+### Set up VSCode
 Afterwards, install Visual Studio Code on your PC, and additionally install and configure the VSCode Remote-SSH Extension: https://code.visualstudio.com/docs/remote/ssh
 When done, connect to the RPi as root via Visual Studio Code.
 Then click `File->Open Folder` and type in `/root/stratux`.
-You should now have the Stratux EU project loaded into VSCode.
+You should now have the Stratux project loaded into VSCode.
 There are preconfigured build an debug tasks in the project which allow you to create a debuggable Stratux build and remote-debug it in VSCode.
 To get started, you need to install the "Go" extensions ("Install on Stratux" while connected via Remote-SSH).
 The extension will ask you to install several tools (including delve if you want to debug). Go ahead and do so.
 Before debugging, run `stxstop` to stop the already running stratux service.
 
 There is also a makefile in the repository, so `make && make install && stxrestart` would be a simple way to build, install and start.
+
+### Save your public key to the pi
+Run on your local machine (On windows use git bash).  Stops VSCode from continually prompting for passwords
+
+```bash
+ssh-copy-id root@stratux
+```
 
 ## Local x86 Linux Setup
 This is an **ADVANCED** setup, which requires experience with the Linux shell, system, and common build processes. Do not open issues if you can't get it to work - you are on your own here.


### PR DESCRIPTION
Updates the exact steps that are necessary to set up a Pi for remote dev.  Tested on a Pi 4 flashed with a fresh image from v2.0-pre5