### PR TITLE
Adds iptables back into the image

### DIFF
--- a/image_build/stage2/10-stratux/01-run.sh
+++ b/image_build/stage2/10-stratux/01-run.sh
@@ -8,7 +8,7 @@
 apt update
 
 on_chroot << EOF
-    apt install --yes dnsmasq ifplugd
+    apt install --yes dnsmasq ifplugd iptables
 
     # try to reduce writing to SD card as much as possible, so they don't get
     # bricked when yanking the power cable


### PR DESCRIPTION
closes #285 

Built image, flashed and tested on Pi 4 to confirm AP+Client mode and internet passthrough are working