### PR TITLE
feat: simplify initIMU, let driver auto-detect I2C address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ test/uatsummary
 
 .DS_Store
 
+
+# Local Go workspace (dev-only)
+go.work
+go.work.sum

--- a/main/sensors.go
+++ b/main/sensors.go
@@ -178,39 +178,20 @@ func tempAndPressureSender() {
 }
 
 func initIMU() (ok bool) {
-	// Check if the chip is the ICM-20948 or MPU-9250.
-	v, err := i2cbus.ReadByteFromReg(0x68, ICMREG_WHO_AM_I)
-	if err != nil {
-		log.Printf("Error identifying IMU: %s\n", err.Error())
-		return false
-	}
-	v2, err := i2cbus.ReadByteFromReg(0x68, MPUREG_WHO_AM_I)
-	if err != nil {
-		log.Printf("Error identifying IMU: %s\n", err.Error())
-		return false
-	}
-
-	if v == ICMREG_WHO_AM_I_VAL {
+	// Drivers auto-detect the chip at I2C 0x68 or 0x69 internally and
+	// return an error if the expected chip isn't present at either address.
+	// Try ICM-20948 first, then fall back to MPU-9250.
+	if imu, err := sensors.NewICM20948(&i2cbus); err == nil {
 		log.Println("ICM-20948 detected.")
-		imu, err := sensors.NewICM20948(&i2cbus)
-		if err == nil {
-			myIMUReader = imu
-			return true
-		}
-	} else if v2 == MPUREG_WHO_AM_I_VAL || v2 == MPUREG_WHO_AM_I_VAL_9255 || v2 == MPUREG_WHO_AM_I_VAL_6500 ||
-		v2 == MPUREG_WHO_AM_I_VAL_60X0 || v2 == MPUREG_WHO_AM_I_VAL_UNKNOWN {
-
-		log.Printf("MPU detected (%02x).\n", v2)
-		imu, err := sensors.NewMPU9250(&i2cbus)
-		if err == nil {
-			myIMUReader = imu
-			return true
-		}
-	} else {
-		log.Printf("Could not identify MPU. v=%02x, v2=%02x.\n", v, v2)
-		return false
+		myIMUReader = imu
+		return true
 	}
-
+	if imu, err := sensors.NewMPU9250(&i2cbus); err == nil {
+		log.Println("MPU-9250 detected.")
+		myIMUReader = imu
+		return true
+	}
+	log.Println("No IMU detected at I2C 0x68 or 0x69.")
 	return false
 }
 


### PR DESCRIPTION
## Problem

`initIMU` does its own `WHO_AM_I` probe at hardcoded I2C `0x68` before invoking the driver:

```go
v, err := i2cbus.ReadByteFromReg(0x68, ICMREG_WHO_AM_I)
if err != nil {
    log.Printf(\"Error identifying IMU: %s\\n\", err.Error())
    return false
}
```

For IMU chips with the AD0 pin tied high (common on Adafruit, Sparkfun, and generic GY-91 breakout boards), the chip lives at `0x69` rather than `0x68`. The pre-probe fails with a remote I/O error, returns false immediately, and the driver is never given a chance to run. Symptom: repeating \`Error identifying IMU: remote I/O error\` every 4 seconds.

Same root cause as #115.

## Fix

Removes the duplicated probe logic from `initIMU` and delegates all address detection to the driver. Companion PR stratux/goflying#2 teaches the ICM-20948 and MPU-9250 drivers to probe both `0x68` and `0x69` internally.

\`initIMU\` is now:

\`\`\`go
func initIMU() (ok bool) {
    if imu, err := sensors.NewICM20948(&i2cbus); err == nil {
        log.Println(\"ICM-20948 detected.\")
        myIMUReader = imu
        return true
    }
    if imu, err := sensors.NewMPU9250(&i2cbus); err == nil {
        log.Println(\"MPU-9250 detected.\")
        myIMUReader = imu
        return true
    }
    log.Println(\"No IMU detected at I2C 0x68 or 0x69.\")
    return false
}
\`\`\`

Net: 31 lines removed, 16 added. Each driver tries; first one that finds its chip wins.

## Why move the probe into the driver?

- **Single source of truth**: only one place encodes the chip's I2C addressing scheme.
- **Drivers know about their own hardware**; application code shouldn't have to.
- **Removes a stale gate**: `initIMU` was failing fast on a hardcoded address that the underlying driver also hardcoded, duplicating bug surface.
- **Public driver signatures unchanged** — no go.mod ripple effects.

## Verification on hardware (Pi 5 / Bookworm / ICM-20948 at 0x69)

i2c bus shows chip at 0x69:
\`\`\`
60: -- -- -- -- -- -- -- -- -- 69 -- -- -- -- -- --
70: -- -- -- -- -- -- -- 77
\`\`\`

Before (existing master, with the goflying changes also unapplied):
\`\`\`
Error identifying IMU: remote I/O error  (every 4s, indefinitely)
\`\`\`

After (this PR + stratux/goflying#2):
\`\`\`
2026/05/14 21:52:09 ICM20948: detected at I2C address 0x69
2026/05/14 21:52:09 ICM-20948 detected.
2026/05/14 21:52:11 AHRS Info: IMU calibration attempt #1
2026/05/14 21:52:11 AHRS Info: IMU gyro calibration: -0.165368 1.343702 -0.363738
2026/05/14 22:02:05 - Last IMU read: now
\`\`\`

IMU samples flowing continuously; AHRS produces live attitude.

## Compatibility

- **Depends on stratux/goflying#2.** Without that PR, this one won't fix anything at runtime (the driver still hardcodes 0x68), but it also won't regress anything: chips at 0x68 keep working through the original code path inside the driver.
- The unused WHO_AM_I constants at the top of `main/sensors.go` (lines 28-35) are now dead code. Left in place to keep this diff minimal; happy to remove in a follow-up if preferred.

## Refs

- Fixes the symptom described in #115
- Companion: stratux/goflying#2