### PR TITLE
Add BMP58x pressure sensor support

### DIFF
--- a/main/sensors.go
+++ b/main/sensors.go
@@ -87,24 +87,31 @@ func initPressureSensor() (ok bool) {
 	if err != nil {
 		v, err = i2cbus.ReadByteFromReg(0x77, PRESSURE_WHO_AM_I)
 	}
-	if err != nil {
-		log.Printf("Error identifying BMP: %s\n", err.Error())
-		return false
-	}
-	if v == bmp388.ChipId || v == bmp388.ChipId390 {
+	if err == nil && (v == bmp388.ChipId || v == bmp388.ChipId390) {
 		log.Printf("BMP-388 detected")
 		bmp, err := sensors.NewBMP388(&i2cbus)
 		if err == nil {
 			myPressureReader = bmp
 			return true
 		}
-	} else {
+	} else if err == nil {
 		log.Printf("using BMP-280")
 		bmp, err := sensors.NewBMP280(&i2cbus, 100*time.Millisecond)
 		if err == nil {
 			myPressureReader = bmp
 			return true
 		}
+	} else {
+		log.Printf("Error identifying BMP: %s\n", err.Error())
+	}
+
+	// Try BMP58x sensors after the existing BMP388/BMP280 paths so current
+	// Stratux hardware keeps its previous detection precedence.
+	bmp58x, err := sensors.NewBMP5XX(&i2cbus)
+	if err == nil {
+		log.Printf("BMP-58x detected")
+		myPressureReader = bmp58x
+		return true
 	}
 
 	return false

--- a/sensors/bmp5xx.go
+++ b/sensors/bmp5xx.go
@@ -54,6 +54,10 @@ func (bmp *BMP5XX) run() {
 		press, pressErr := bmp.sensor.ReadPressure()
 		temp, tempErr := bmp.sensor.ReadTemperature()
 		if pressErr != nil || tempErr != nil {
+			bmp.mu.Lock()
+			bmp.pressure = 0
+			bmp.temperature = 0
+			bmp.mu.Unlock()
 			continue
 		}
 
@@ -90,4 +94,3 @@ func (bmp *BMP5XX) Pressure() (float64, error) {
 
 	return bmp.pressure, nil
 }
-

--- a/sensors/bmp5xx.go
+++ b/sensors/bmp5xx.go
@@ -1,0 +1,93 @@
+package sensors
+
+import (
+	"sync"
+	"time"
+
+	"github.com/kidoman/embd"
+	"github.com/stratux/stratux/sensors/bmp5xx"
+)
+
+type BMP5XX struct {
+	sensor      *bmp5xx.BMP5XX
+	temperature float64
+	pressure    float64
+	running     bool
+	mu          sync.RWMutex
+}
+
+func NewBMP5XX(i2cbus *embd.I2CBus) (*BMP5XX, error) {
+	var bmp *bmp5xx.BMP5XX
+
+	for _, address := range []byte{bmp5xx.Address1, bmp5xx.Address2} {
+		candidate := &bmp5xx.BMP5XX{Address: address, Bus: i2cbus}
+		if candidate.Connected() {
+			bmp = candidate
+			break
+		}
+	}
+
+	if bmp == nil {
+		return nil, bmp5xx.ErrNotConnected
+	}
+	if err := bmp.Configure(); err != nil {
+		return nil, err
+	}
+
+	newBmp := &BMP5XX{sensor: bmp, running: true}
+	go newBmp.run()
+	return newBmp, nil
+}
+
+func (bmp *BMP5XX) run() {
+	clock := time.NewTicker(100 * time.Millisecond)
+	defer clock.Stop()
+
+	for range clock.C {
+		bmp.mu.RLock()
+		running := bmp.running
+		bmp.mu.RUnlock()
+		if !running {
+			return
+		}
+
+		press, pressErr := bmp.sensor.ReadPressure()
+		temp, tempErr := bmp.sensor.ReadTemperature()
+		if pressErr != nil || tempErr != nil {
+			continue
+		}
+
+		bmp.mu.Lock()
+		bmp.pressure = press
+		bmp.temperature = temp
+		bmp.mu.Unlock()
+	}
+}
+
+func (bmp *BMP5XX) Close() {
+	bmp.mu.Lock()
+	bmp.running = false
+	bmp.mu.Unlock()
+	bmp.sensor.Close()
+}
+
+func (bmp *BMP5XX) Temperature() (float64, error) {
+	bmp.mu.RLock()
+	defer bmp.mu.RUnlock()
+	if !bmp.running {
+		return 0, bmp5xx.ErrNotConnected
+	}
+
+	return bmp.temperature, nil
+}
+
+func (bmp *BMP5XX) Pressure() (float64, error) {
+	bmp.mu.RLock()
+	defer bmp.mu.RUnlock()
+	if !bmp.running {
+		return 0, bmp5xx.ErrNotConnected
+	}
+
+	return bmp.pressure, nil
+}
+

--- a/sensors/bmp5xx/bmp5xx.go
+++ b/sensors/bmp5xx/bmp5xx.go
@@ -1,0 +1,88 @@
+package bmp5xx
+
+import (
+	"time"
+
+	"github.com/kidoman/embd"
+)
+
+type BMP5XX struct {
+	Bus     *embd.I2CBus
+	Address byte
+}
+
+func (d *BMP5XX) Connected() bool {
+	chipID, err := d.readByte(RegChipId)
+	return err == nil && isSupportedChipID(chipID)
+}
+
+func (d *BMP5XX) Configure() error {
+	if !d.Connected() {
+		return ErrNotConnected
+	}
+
+	if err := d.writeRegister(RegOsrConfig, osrTemperature8X|osrPressure2X|osrPressureEn); err != nil {
+		return errConfigWrite
+	}
+	if err := d.writeRegister(RegOdrConfig, odr10Hz|powerModeNormal|deepStandbyDisabled); err != nil {
+		return errConfigWrite
+	}
+
+	time.Sleep(5 * time.Millisecond)
+	return nil
+}
+
+func (d *BMP5XX) ReadTemperature() (float64, error) {
+	data, err := d.readRegister(RegTemperatureData, 3)
+	if err != nil {
+		return 0, errDataRead
+	}
+
+	raw := signExtend24(data)
+	return float64(raw) / 65536.0, nil
+}
+
+func (d *BMP5XX) ReadPressure() (float64, error) {
+	data, err := d.readRegister(RegPressureData, 3)
+	if err != nil {
+		return 0, errDataRead
+	}
+
+	raw := uint32(data[2])<<16 | uint32(data[1])<<8 | uint32(data[0])
+	return float64(raw) / 6400.0, nil
+}
+
+func (d *BMP5XX) Close() {
+	_ = d.writeRegister(RegOdrConfig, 0)
+}
+
+func isSupportedChipID(chipID byte) bool {
+	return chipID == ChipIdBMP580 || chipID == ChipIdBMP585
+}
+
+func signExtend24(data []byte) int32 {
+	raw := int32(uint32(data[2])<<16 | uint32(data[1])<<8 | uint32(data[0]))
+	if raw&0x800000 != 0 {
+		raw |= ^0xFFFFFF
+	}
+	return raw
+}
+
+func (d *BMP5XX) readRegister(register byte, len int) ([]byte, error) {
+	data := make([]byte, len)
+	err := (*d.Bus).ReadFromReg(d.Address, register, data)
+	return data, err
+}
+
+func (d *BMP5XX) readByte(register byte) (byte, error) {
+	data, err := d.readRegister(register, 1)
+	if err != nil {
+		return 0, err
+	}
+	return data[0], nil
+}
+
+func (d *BMP5XX) writeRegister(register byte, data byte) error {
+	return (*d.Bus).WriteToReg(d.Address, register, []byte{data})
+}
+

--- a/sensors/bmp5xx/bmp5xx.go
+++ b/sensors/bmp5xx/bmp5xx.go
@@ -68,8 +68,8 @@ func signExtend24(data []byte) int32 {
 	return raw
 }
 
-func (d *BMP5XX) readRegister(register byte, len int) ([]byte, error) {
-	data := make([]byte, len)
+func (d *BMP5XX) readRegister(register byte, count int) ([]byte, error) {
+	data := make([]byte, count)
 	err := (*d.Bus).ReadFromReg(d.Address, register, data)
 	return data, err
 }
@@ -85,4 +85,3 @@ func (d *BMP5XX) readByte(register byte) (byte, error) {
 func (d *BMP5XX) writeRegister(register byte, data byte) error {
 	return (*d.Bus).WriteToReg(d.Address, register, []byte{data})
 }
-

--- a/sensors/bmp5xx/registers.go
+++ b/sensors/bmp5xx/registers.go
@@ -1,0 +1,50 @@
+// Package bmp5xx provides a small I2C driver for Bosch BMP58x pressure sensors.
+//
+// Register definitions and data conversion are based on Bosch Sensortec's
+// BMP5 Sensor API:
+// https://github.com/boschsensortec/BMP5_SensorAPI
+package bmp5xx
+
+import "errors"
+
+const (
+	Address1 byte = 0x46
+	Address2 byte = 0x47
+)
+
+const (
+	RegChipId    byte = 0x01
+	RegStatus    byte = 0x28
+	RegOsrConfig byte = 0x36
+	RegOdrConfig byte = 0x37
+	RegCmd       byte = 0x7E
+
+	RegTemperatureData byte = 0x1D
+	RegPressureData    byte = 0x20
+)
+
+const (
+	ChipIdBMP580 byte = 0x50
+	ChipIdBMP581 byte = 0x50
+	ChipIdBMP585 byte = 0x51
+	ChipIdBMP587 byte = 0x51
+
+	SoftReset byte = 0xB6
+)
+
+const (
+	osrTemperature8X byte = 0x03
+	osrPressure2X    byte = 0x01 << 3
+	osrPressureEn    byte = 0x01 << 6
+
+	odr10Hz             byte = 0x17 << 2
+	powerModeNormal     byte = 0x01
+	deepStandbyDisabled byte = 0x01 << 7
+)
+
+var (
+	ErrNotConnected = errors.New("bmp5xx: not connected")
+	errConfigWrite  = errors.New("bmp5xx: failed to configure sensor, check connection")
+	errDataRead     = errors.New("bmp5xx: failed to read sensor data")
+)
+


### PR DESCRIPTION
Adds optional Bosch BMP58x/BMP5xx pressure sensor support.

- Keeps existing BMP388/BMP390 and BMP280 detection first
- Tries BMP58x only afterward at 0x46/0x47
- Uses exact chip ID matching before enabling the new reader
- Adds a PressureReader wrapper compatible with existing Stratux baro code

built the image, then tested myself on Raspberry Pi with sparksfun BMP581 connected over I2C, the web UI interface gives the correct Chandler local bar pressure
Existing sensor behavior should be unchanged when BMP58x is absent.