### PR TITLE
Support for a shutdown button

### DIFF
--- a/image_build/stage2/10-stratux/files/config.txt
+++ b/image_build/stage2/10-stratux/files/config.txt
@@ -29,3 +29,6 @@ core_freq=450
 arm_freq=900
 
 arm_64bit=1
+
+# enablement for a shutdown button on gpio 5
+dtoverlay=gpio-shutdown,gpio_pin=5

--- a/image_build/stage2/10-stratux/files/config.txt
+++ b/image_build/stage2/10-stratux/files/config.txt
@@ -30,5 +30,5 @@ arm_freq=900
 
 arm_64bit=1
 
-# enablement for a shutdown button on gpio 5
-dtoverlay=gpio-shutdown,gpio_pin=5
+# enablement for a shutdown button on gpio 5 with 3 sec press
+dtoverlay=gpio-shutdown,gpio_pin=5,debounce=3000


### PR DESCRIPTION
Pulling the power off the RPi has the potential of damaging files on the SD card. The correct way is to shutdown from the UI before disconnecting power. Easy to skip at the end of a flight.

A more convenient way for a graceful shutdown is a button on the device itself. Press the button, and there's no need to disconnect the battery.

This small change adds the `gpio-shutdown` overlay in the RPi's `config.txt`. If GPIO 5 (header pin 29) is grounded a graceful shutdown will be initiated. The default for the overlay is GPIO 3. This pin has the advantage that if it is grounded again while power is connected the RPi will start up. However, GPIO 3 is an I2C pin, and could be occupied by the AHRS 2.0 (ICM-20948 + BMP280) board. GPIO 5 is next to a GND pin (header pin 30) so it's convenient for wiring.

tjk :)